### PR TITLE
PLANET-6301 Upgrade Cloudflare plugin to 4.6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "greenpeace/planet4-plugin-medialibrary" : "v1.14",
     "wikimedia/composer-merge-plugin": "2.0.*",
     "wpackagist-plugin/akismet": "4.*",
-    "wpackagist-plugin/cloudflare" : "3.8.6",
+    "wpackagist-plugin/cloudflare" : "4.6.0",
     "wpackagist-plugin/duplicate-post": "3.*",
     "wpackagist-plugin/elasticpress":"3.5.*",
     "wpackagist-plugin/gdpr-comments":"1.0.2",


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6301

Going through the [Changelog](https://github.com/cloudflare/Cloudflare-WordPress/releases) didn't reveal any breaking changes. But I tested the two main features we use.

1. Purging all published pages on `make post-deploy` [works fine](https://app.circleci.com/pipelines/github/greenpeace/planet4-test-umbriel/54/workflows/849c2c28-3b13-401e-ac55-1d381fc3d804/jobs/314).
2. Tested with Private mode, editing a post purges it from Cloudflare cache. On next request I see `cf-cache-status: MISS`.