### PR TITLE
Upgrade Google Profile Avatars to 1.6.0

### DIFF
--- a/tasks/post-deploy/05-google-profile-avatars.sh
+++ b/tasks/post-deploy/05-google-profile-avatars.sh
@@ -3,4 +3,7 @@
 echo "Configure Google Profile Avatars plugin..."
 wp option add gpavatars_options '{"gpa_license_key": ""}' --format=json || true
 wp option patch update gpavatars_options gpa_license_key "${GOOGLE_PROFILE_AVATARS_KEY%$'\n'}"
-wp plugin activate google-profile-avatars
+
+# Temporary fix for upgrading the plugin with new zip filename
+wp plugin deactivate google-profile-avatars
+wp plugin install --activate https://storage.googleapis.com/planet4-3rdparty-plugins/googleprofileavatar-premium-1.6.0.zip


### PR DESCRIPTION
## Summary 

This fixes the deprecation warnings after WP 6.9 upgrade. 

They changed the zip filename, and the update with composer doesn't work because it conflicts with the existing version.

```
PHP Fatal error:  Cannot redeclare GoogleProfileAvatar() (previously declared in wp-content/plugins/googleprofileavatar-premium/google_profile_avatars.php:251) in wp-content/plugins/google-profile-avatars/google_profile_avatars.php on line 241
```

So we need to do it in two steps:
1. Deactivate the old plugin and install the new one using wp-cli
2. On a follow up PR we can remove the old plugin from composer requirements and add the new one

### Testing

On local environment:
1. Run the two commands:
```
npx wp-env run cli wp plugin deactivate google-profile-avatars
npx wp-env run cli wp plugin install --activate https://storage.googleapis.com/planet4-3rdparty-plugins/googleprofileavatar-premium-1.6.0.zip
```
2. Visit _Plugins_ page in the Admin Panel. You should see two "Google Profile Avatars" plugins. The one deactivated is `1.5` and the one active is `1.6.0`.
3. Settings and option keys are preserved. By clicking _Settings_ on the activated plugin you should see the license key already being there.