### PR TITLE
Disable composer blocking policy on active advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -194,6 +194,11 @@
 
   "config": {
     "secure-http": false,
+    "policy": {
+      "advisories": {
+        "block": false
+      }
+    },
     "github-protocols": ["https"],
     "allow-plugins": {
       "composer/installers": true,


### PR DESCRIPTION
This was introduced at composer 2.9. We can still see active advisories with `composer audit` but we can unblock the environment installation.

### Testing

1. On a fresh develop environment, edit `.p4-env.json` and change `planet-base` branch to `advisories-unblock`.
2. Continue with the next steps of installing the environemnt
3. Installation should be successful